### PR TITLE
Reworked receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ If you want to see a full DMX package, see the
 ## Receiving
 **BETA!**
 
-This is currently the only implemented feature. The simplest way to receive sACN packets is 
-to use `sacn.Receiver`.
+The simplest way to receive sACN packets is to use `sacn.NewReceiverSocket`.
 
 The receiver checks for out-of-order packets (inspecting the sequence number) and sorts for priority.
 The channel only gets used for changed DMX data, so it behaves like a change listener.
@@ -37,29 +36,32 @@ import (
 )
 
 func main() {
-	recv, err := sacn.Receive(1, "") //receive on the universe 1 and bind to all interfaces
+	recv, err := sacn.NewReceiverSocket("", nil)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
-	go func() { //print every error that occurs
-		for i := range recv.ErrChan {
-			fmt.Println(i)
+	defer recv.Close()
+	recv.ActivateUniverse(1, false) // universe 1 received via unicast
+	recv.ActivateUniverse(2, true) //this should use unicast + multicast, but this will only work on
+	//certain operating systems. Because we provided nil as interface in the constructor.
+
+	go func() {
+		for j := range recv.ErrChan {
+			fmt.Println(j)
 		}
 	}()
-	for j := range recv.DataChan {
-		fmt.Println(j.Data())
+	for p := range recv.DataChan {
+		fmt.Println(p.Data())
 	}
-	//recv.Stop() //use this to stop the receiving of messages and close the channel
-	//Note: This does not stop immediately the channels, worst case: it takes 2,5 seconds
 }
 ```
 
 ### Multicast
 
-This `Receiver` uses multicast groups to receive its data. Unicast packets that are received
+This `sacn.ReceiverSocket` can use multicast groups to receive its data. Unicast packets that are received
 are also processed like the normal unicast receiver. Depending on your operating system, you might can 
 provide `nil` as an interface, sometimes you have to use a dedicated interface, to get multicast working.
-Windows needs an interface and linux generally not.
+Windows needs an interface and Linux generally not.
 
 Note that the network infrastructure has to be multicast ready and that on some networks the delay of 
 packets will increase. Also the packet loss can be higher if multicast is choosen. This can cause 
@@ -82,21 +84,24 @@ func main() {
 	//see the net package for more information
 	ifi, err := net.InterfaceByName("WLAN")
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
-	//the use of a dedicated interface is dependend on your OS
-	//if you use Windows you have to provide an interface, on other OS you might not
-	recv, err := sacn.ReceiveMulticast(1, ifi) //receive on the universe 1 and bind to the interface
+	recv, err := sacn.NewReceiverSocket("", ifi) //use the interface we searched for as interface for
+	//multicast use
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
+	defer recv.Close()
+	recv.ActivateUniverse(1, false) //universe 1 is received via unicast
+	recv.ActivateUniverse(2, true) //universe 2 is received via unicast + multicast
+
 	go func() {
-		for i := range recv.ErrChan {
-			fmt.Println(i) //print every error that occurs
+		for j := range recv.ErrChan {
+			fmt.Println(j)
 		}
 	}()
-	for j := range recv.DataChan {
-		fmt.Println(j.Data())
+	for p := range recv.DataChan {
+		fmt.Println(p.Data())
 	}
 }
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ func main() {
 You can stop the receiving of packets on a Receiver via `receiver.Stop()`. 
 Please note that it can take up to 2,5s to stop the receiving and close all channels.
 If you have stoped a receiver once, you can not start listening again. You have to create a 
-new `Receiver` object via `sacn.NewReceiver()`.
+new `Receiver` object via `sacn.NewReceiverSocket()`.
 
 ## Transmitting
 

--- a/sacn/doc.go
+++ b/sacn/doc.go
@@ -1,0 +1,166 @@
+/*
+Package sacn is a simple sACN implementation. The standard can be obtained here: http://tsp.esta.org/tsp/documents/docs/E1-31-2016.pdf
+
+This is by no means a full implementation yet, but may be in the future.
+If you want to see a full DMX package, see the
+[OLA](http://opendmx.net/index.php/Open_Lighting_Architecture) project.
+
+Receiving
+
+The simplest way to receive sACN packets is to use `sacn.NewReceiverSocket`.
+
+The receiver checks for out-of-order packets (inspecting the sequence number) and sorts for priority.
+The channel only gets used for changed DMX data, so it behaves like a change listener.
+Note: if two or more sources are transmitting on the same universe with the same priority,
+there will be errors send through the error channel with "sources exceeded" as text.
+No data will be transmitted through the data channel.
+Synchronization must be implemented in your program, but currently there is no way to receive
+the sACN sync-packets. This feature may come in a future version.
+Please note: This implementation is subjected to change!
+
+Unicast
+
+Example for simple unicast listener:
+
+	package main
+
+	import (
+		"fmt"
+
+		"github.com/Hundemeier/go-sacn/sacn"
+	)
+
+	func main() {
+		recv, err := sacn.NewReceiverSocket("", nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer recv.Close()
+		recv.ActivateUniverse(1, false) // universe 1 received via unicast
+		recv.ActivateUniverse(2, true) //this should use unicast + multicast, but this will only work on
+		//certain operating systems. Because we provided nil as interface in the constructor.
+
+		go func() {
+			for j := range recv.ErrChan {
+				fmt.Println(j)
+			}
+		}()
+		for p := range recv.DataChan {
+			fmt.Println(p.Data())
+		}
+	}
+
+Multicast
+
+This `sacn.ReceiverSocket` can use multicast groups to receive its data. Unicast packets that are received
+are also processed like the normal unicast receiver. Depending on your operating system, you might can
+provide `nil` as an interface, sometimes you have to use a dedicated interface, to get multicast working.
+Windows needs an interface and Linux generally not.
+
+Note that the network infrastructure has to be multicast ready and that on some networks the delay of
+packets will increase. Also the packet loss can be higher if multicast is choosen. This can cause
+unintentional timeouts, if the sources are only transmitting every 2 seconds (like grandMA2 consoles).
+Please test your network for more information.
+
+Example for multicast use:
+
+	package main
+
+	import (
+		"fmt"
+		"net"
+
+		"github.com/Hundemeier/go-sacn/sacn"
+	)
+
+	func main() {
+		//get the interface we use to listen via multicast
+		//see the net package for more information
+		ifi, err := net.InterfaceByName("WLAN")
+		if err != nil {
+			log.Fatal(err)
+		}
+		recv, err := sacn.NewReceiverSocket("", ifi) //use the interface we searched for as interface for
+		//multicast use
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer recv.Close()
+		recv.ActivateUniverse(1, false) //universe 1 is received via unicast
+		recv.ActivateUniverse(2, true) //universe 2 is received via unicast + multicast
+
+		go func() {
+			for j := range recv.ErrChan {
+				fmt.Println(j)
+			}
+		}()
+		for p := range recv.DataChan {
+			fmt.Println(p.Data())
+		}
+	}
+
+Stoping
+
+You can stop the receiving of packets on a Receiver via `receiver.Stop()`.
+Please note that it can take up to 2,5s to stop the receiving and close all channels.
+If you have stoped a receiver once, you can not start listening again. You have to create a
+new `Receiver` object via `sacn.NewReceiverSocket()`.
+
+Transmitting
+
+To transmitt DMX data, you have to initalize a `Transmitter` object. This handles all the protocol
+specific actions (currently not all). You can activate universes, if you wish to send out data.
+Then you can use a channel for 512-byte arrays to transmitt them over the network.
+
+There are two different types of addressing the receiver: unicast and multicast.
+When using multicast, note that you have to provide a bind address on some operating systems
+(eg Windows). You can use both at the same time and any number of unicast addresses.
+To set wether multicast should be used, call `transmitter.SetMulticast(<universe>, <bool>)`.
+You can set multiple unicast destinations as slice via
+`transmitter.SetDestinations(<universe>, <[]string>)`.
+Note that any existing destinations will be overwritten. If you want to append a destination, you
+can use `transmitter.Destination(<universe>)` which returns a deep copy of the used net.UDPAddr
+objects.
+
+Example
+
+	package main
+
+	import (
+		"log"
+		"math/rand"
+		"time"
+
+		"github.com/Hundemeier/go-sacn/sacn"
+	)
+
+	func main() {
+		//instead of "" you could provide an ip-address that the socket should bind to
+		trans, err := sacn.NewTransmitter("", [16]byte{1, 2, 3}, "test")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		//activates the first universe
+		ch, err := trans.Activate(1)
+		if err != nil {
+			log.Fatal(err)
+		}
+		//deactivate the channel on exit
+		defer close(ch)
+
+		//set a unicast destination, and/or use multicast
+		trans.SetMulticast(1, true)//this specific setup will not multicast on windows,
+		//because no bind address was provided
+
+		//set some example ip-addresses
+		trans.SetDestinations(1, []string{"192.168.1.13", "192.168.1.1"})
+
+		//send some random data for 10 seconds
+		for i := 0; i < 20; i++ {
+			ch <- [512]byte{byte(rand.Int()), byte(i & 0xFF)}
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+*/
+package sacn

--- a/sacn/functions.go
+++ b/sacn/functions.go
@@ -3,6 +3,7 @@ package sacn
 import (
 	"fmt"
 	"math"
+	"net"
 )
 
 //CalculateFal : Calculates the two bytes of a FlagsAndLength field of a sACN packet
@@ -31,4 +32,9 @@ func getAsUint32(arr []byte) uint32 {
 func calcMulticastAddr(universe uint16) string {
 	byt := getAsBytes16(universe)
 	return fmt.Sprintf("239.255.%v.%v", byt[0], byt[1])
+}
+
+func calcMulticastUDPAddr(universe uint16) *net.UDPAddr {
+	addr, _ := net.ResolveUDPAddr("udp", calcMulticastAddr(universe)+":5568")
+	return addr
 }

--- a/sacn/receiverFunctions.go
+++ b/sacn/receiverFunctions.go
@@ -1,0 +1,122 @@
+package sacn
+
+import (
+	"net"
+	"time"
+
+	"golang.org/x/net/ipv4"
+)
+
+//Set the timout according to the E1.31 protocol
+const timeoutMs = 2500
+
+//ReceiverSocket is used to listen on a network interface for sACN data.
+//All the data that is arrived, and was activated is send to the DataChan.
+//All errors from all universes are send through the ErrChan.
+//This Receiver checks for out-of-order packets and sorts out packets with too low priority.
+//Note: if there are two sources with the same highest priority, there will be send a
+//"sources exceeded" error in the error channel.
+//Furthermore: through the channel only changed data will be send.
+//So the sequence numbers may not be in order.
+type ReceiverSocket struct {
+	DataChan     chan DataPacket
+	ErrChan      chan ReceiveError
+	socket       *ipv4.PacketConn
+	stopListener chan struct{}
+	activated    map[uint16]struct{}
+	//a map that stores, wether a universe is activated for listening or not. It is used like a set
+	//se methods: isActive, setActive
+	lastDatas          map[uint16]*lastData
+	multicastInterface *net.Interface // the interface that is used for joining multicast groups
+}
+
+type lastData struct {
+	sources     map[[16]byte]source
+	lastTime    time.Time
+	lastSequ    byte
+	lastDMXdata []byte
+}
+
+//ReceiveError contains the universe from which the error occured and the error itself
+type ReceiveError struct {
+	Universe uint16
+	Error    error
+}
+
+/*
+ActivateUniverse activates a universe for listening, so every data is send through the dataChannel
+if multicast is true, the corresponding multicast group will be joined, if you provided an interface
+in the `NewReceiverSocket`.
+*/
+func (r *ReceiverSocket) ActivateUniverse(universe uint16, multicast bool) {
+	//activate universe and set the lastData object for the handling
+	r.setActive(universe, true)
+	r.lastDatas[universe] = &lastData{
+		sources:  make(map[[16]byte]source),
+		lastTime: time.Now(),
+	}
+	if multicast {
+		r.socket.JoinGroup(r.multicastInterface, calcMulticastUDPAddr(universe))
+	}
+}
+
+//DeactivateUniverse deactivates a universe from listening and no further data will be send through the
+//data channel. If `universe` was not activated, nothing will happen.
+func (r *ReceiverSocket) DeactivateUniverse(universe uint16) {
+	r.setActive(universe, false)
+	delete(r.lastDatas, universe)
+	r.socket.LeaveGroup(r.multicastInterface, calcMulticastUDPAddr(universe))
+}
+
+//Close will close the open udp socket and close the data and error channel.
+//If you want to receive again, create a new ReceiverSocket object. Do not call close twice!
+func (r *ReceiverSocket) Close() {
+	close(r.stopListener) // stop the running listener on the socket, because we will close the socket
+	close(r.DataChan)
+	close(r.ErrChan)
+}
+
+func (r *ReceiverSocket) isActive(universe uint16) bool {
+	if _, ok := r.activated[universe]; ok {
+		return true
+	}
+	return false
+}
+
+func (r *ReceiverSocket) setActive(universe uint16, active bool) {
+	if active {
+		r.activated[universe] = struct{}{}
+	} else {
+		delete(r.activated, universe)
+	}
+}
+
+//GetAllActive returns a slice with all active universes
+func (r *ReceiverSocket) GetAllActive() []uint16 {
+	tmp := make([]uint16, 0)
+	for key := range r.activated {
+		tmp = append(tmp, key)
+	}
+	return tmp
+}
+
+func equalData(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func errToCh(universe uint16, err error, ch chan ReceiveError) {
+	if err != nil {
+		ch <- ReceiveError{
+			Universe: universe,
+			Error:    err,
+		}
+	}
+}


### PR DESCRIPTION
This is a complete rework of the receiver part of this library. Multicast and unicast are no longer seperated and can be used together. 
This breaks all exisitng code that uses the Receiver feature. The rewriting of exisitng code is not a trivial task, so please read the Readme again for more information.